### PR TITLE
Fix for 410 on community restricted videos

### DIFF
--- a/lib/info.js
+++ b/lib/info.js
@@ -126,7 +126,7 @@ const isNotYetBroadcasted = player_response => {
 };
 
 
-const getWatchHTMLURL = (id, options) => `${BASE_URL + id}&hl=${options.lang || 'en'}`;
+const getWatchHTMLURL = (id, options) => `${BASE_URL + id}&hl=${options.lang || 'en'}&bpctr=9999999999&has_verified=1`;
 const getWatchHTMLPageBody = (id, options) => {
   const url = getWatchHTMLURL(id, options);
   return exports.watchPageCache.getOrSet(url, () => utils.exposedMiniget(url, options).text());


### PR DESCRIPTION
### Issue

Community age restricted videos on Youtube (the ones that require clicking the "I understand and wish to proceed" button before watching) were causing the module to throw a 410 when trying a `getInfo`

### Cause

`getInfo` runs through a maximum of 3 urls until it has enough metadata (as defined in the validate function on info.js:59). Often we can get enough data from the first url (the basic watch page) to satisfy this and exit early, unfortunately no formats are made available when a video requires the user to click that age restricted button. The other URLs are visited and the last one in the list (`youtube.com/get_video_info`) throws a 410 Gone, causing the module to also throw. 

### Solution

Appending `&bpctr=9999999999&has_verified=1` to the first url (the basic watch page) seems to bypass that "I understand and wish to proceed" button and makes the format/stream data available right away, thus eliminating the need to visit the other URLs and never calling out to the `youtube.com/get_video_info` url

### Related

I didn't discover this, I simply ran into the problem and was searching for solutions. There have been conversations on this repo in issues and PRs about this (https://github.com/fent/node-ytdl-core/issues/1009 and https://github.com/fent/node-ytdl-core/pull/1010) but they've been closed/dismissed as being fixed under https://github.com/fent/node-ytdl-core/pull/1022. This does not seem to be the case for me (and at least a few other users). 

Here's a video I've been using to test with https://www.youtube.com/watch?v=lwVhz0QCFEY (you can also see here that adding &bpctr=9999999999&has_verified=1 to the end of that URL gets rid of the prompt and starts playing immediately. 

Code can be tested with the following test function

```
async function start() {
	  try { 
	  	const info = await getInfo('lwVhz0QCFEY') 
	  } catch(e) {
	    console.error(e)
	  }
}
```
